### PR TITLE
Bug/console error query selector all

### DIFF
--- a/cookie-manager.js
+++ b/cookie-manager.js
@@ -344,7 +344,7 @@ const cookieManager = (function () {
             // User has preferences set, no need to show cookie banner.
             if (!theBanner.classList.contains(bannerVisibilityClass)) {
                 theBanner.classList.add(bannerVisibilityClass);
-                console.debug('Cookie banner was set to visible.')
+                console.debug('Cookie banner was set to invisible.');
             }
         } else {
             if (user_preference_form !== null && visible_on_preference_page === false) {

--- a/cookie-manager.js
+++ b/cookie-manager.js
@@ -36,7 +36,9 @@ const cookieManager = (function () {
         console.debug(options);
 
         manageCookies(options);
-        findAndBindPreferencesForm(options);
+        if (document.getElementById(custom_options['user-preference-configuration-form-id'])) {
+            findAndBindPreferencesForm(options);
+        }
         findAndBindCookieBanner(options);
     };
 


### PR DESCRIPTION
### Description
Fixes an issue which throws an error in the console because the id for the preferences form returns null.

`Uncaught TypeError: Cannot read property 'querySelectorAll' of null`

- The findAndBindPreferencesForm function is only called if the cooke preferences form element is found
- Corrected debug log for detailing the cookie banner visibility