### PR TITLE
Fix for module.exports causing reference error on calling init

### DIFF
--- a/cookie-manager.js
+++ b/cookie-manager.js
@@ -1,6 +1,8 @@
-"use strict";
-
-const cookieManager = (function () {
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+	typeof define === 'function' && define.amd ? define('cookieManager', ['exports'], factory) :
+	(factory((global.cookieManager = {})));
+}(this, (function (exports) { 'use strict';
 
     // Prevents JavaScript errors when running on browsers without console/log.
     if(typeof console === "undefined") {
@@ -430,10 +432,6 @@ const cookieManager = (function () {
             && options[optionName].length > 0;
     };
 
-    return {
-        init: init
-    }
+    exports.init = init;
 
-})();
-
-module.exports = cookieManager;
+})));

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Title</title>
-    <script src="/cookie-manager.js"></script>
+    <script src="./cookie-manager.js"></script>
     <script>
         var x = {
             "user-preference-configuration-form-id": "cookie-manager-form",
@@ -38,7 +38,7 @@
                 }
             ]
         };
-        cm.init(x);
+        cookieManager.init(x);
     </script>
     </head>
     <style type="text/css">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cookie-manager",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Cookie Manager is a Javascript library for dealing with cookie compliance.",
   "main": "cookie-manager.js",
   "scripts": {


### PR DESCRIPTION
- Need to ensure the module api exists before attempting to export the
cookie manager module
- Bumped patch version to 1.0.11
- Fix for issue #13